### PR TITLE
start scrolling after the page resets to the top

### DIFF
--- a/jquery.auto-scroll.js
+++ b/jquery.auto-scroll.js
@@ -148,6 +148,9 @@
 												if (self.options.by === "page") {
 													pauseHeight = elementHeight;
 												}
+												//restart scrolling once the page has been reset to the top
+												tween.play();
+
 
 												$(self.element).trigger("done");
 											}


### PR DESCRIPTION
fixes issue: https://github.com/Rise-Vision/widget-earnings-announcements/issues/32

could @donnapep review and merge?
Thank You.
