### PR TITLE
Improved widget "Play Until Done" transition

### DIFF
--- a/jquery.auto-scroll.js
+++ b/jquery.auto-scroll.js
@@ -144,16 +144,11 @@
 									onComplete: function() {
 										tween.seek(0).pause();
 
-										TweenLite.to(self.page, 1, {
-											autoAlpha: 1,
-											onComplete: function() {
-												if (self.options.by === "page") {
-													pauseHeight = elementHeight;
-												}
+										if (self.options.by === "page") {
+											pauseHeight = elementHeight;
+										}
 
-												$(self.element).trigger("done");
-											}
-										});
+										$(self.element).trigger("done");
 									}
 								});
 							}
@@ -179,6 +174,7 @@
 					isLoading = false;
 				}
 				else {
+					TweenLite.to(this.page, 1, {autoAlpha: 1});
 					TweenLite.delayedCall(this.options.pause,
 							resumeTween = function() {
 						tween.play();


### PR DESCRIPTION
- In the scenario of PUD, after fading content out, instead of fading content back in to show at the top and then triggering "done", trigger "done" immediately
- In `play()` function, adding in a fade-in to ensure the visibility of the `page` content gets revealed if it was previously hidden (which would mean the widget has PUD selected)
