### PR TITLE
Add "click" option and capture a click on the scroll element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,10 @@
 {
   "name": "auto-scroll",
+  "version": "1.0.0",
   "homepage": "https://github.com/Rise-Vision/auto-scroll",
   "authors": [
-    "donnapep"
+    "donnapep",
+    "stulees"
   ],
   "description": "Auto-scroll is a jQuery plugin that can be integrated into Widgets to enable auto-scroll and swipe functionality.",
   "main": "jquery.auto-scroll.js",


### PR DESCRIPTION
- Adding a new default option `click` which is `false` by default to allow for the scroll element to capture a click event or not
- Adding a local boolean to the plugin `clicked` to maintain if a click occurred
- Move `calculateProgress` being defined within `init` function and provide a reusable `pauseTween` function
- Listening for `click` event on the `Draggable` instance and ensuring to pause the tween, flag a click occurred, and trigger a "scrollClick" event providing the `pointerEvent` info from the Draggable instance
- `play()` now checks if there was previously a click and if so, call calculate progress`calculateProgress`
- Now adding a version `1.0.0` so releases can be initiated