### PR TITLE
Fix destroy() and allow for clickable non-scrollable content

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-scroll",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "homepage": "https://github.com/Rise-Vision/auto-scroll",
   "authors": [
     "donnapep",

--- a/jquery.auto-scroll.js
+++ b/jquery.auto-scroll.js
@@ -168,6 +168,21 @@
 
 				// Hide scrollbar.
 				TweenLite.set(this.element, { overflowY: "hidden" });
+			} else {
+				if (this.options.click) {
+					// Account for content that is to be clicked when content not needed to be scrolled
+					// Leverage Draggable for touch/click event handling
+					Draggable.create(this.element, {
+						type: "scrollTop",
+						throwProps: true,
+						edgeResistance: 0.95,
+						onClick: function() {
+							$(self.element).trigger("scrollClick", [this.pointerEvent]);
+						}
+					});
+
+					this.draggable = Draggable.get(this.element);
+				}
 			}
 		},
 		// Check if content is larger than viewable area and if the scroll settings is set to actually scroll.
@@ -176,8 +191,13 @@
 		},
 		destroy: function() {
 			$(this.element).removeData();
-			this.tween.kill();
-			this.draggable.kill();
+			if (this.tween) {
+				this.tween.kill();
+			}
+
+			if (this.draggable) {
+				this.draggable.kill();
+			}
 
 			// Remove elements.
 			this.element = null;


### PR DESCRIPTION
- Checking `this.tween` and `this.draggable` exist in case they were not created in the `init()` function based on `canScroll` conditional
- Allowing content that is not scrollable to be clickable, leveraging Draggable to do so by high `edgeResistance` and the `click` handling
- Version bump