### PR TITLE
Adding support for applying an option minimum movement threshold

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-scroll",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "homepage": "https://github.com/Rise-Vision/auto-scroll",
   "authors": [
     "donnapep",

--- a/jquery.auto-scroll.js
+++ b/jquery.auto-scroll.js
@@ -13,7 +13,8 @@
 			by: "continuous",
 			speed: "medium",
 			pause: 5,
-			click: false
+			click: false,
+			minimumMovement: 3 // Draggable default value - http://greensock.com/docs/#/HTML5/Drag/Draggable/
 		};
 
 
@@ -105,6 +106,7 @@
 					type: "scrollTop",
 					throwProps: true,
 					edgeResistance: 0.75,
+					minimumMovement: self.options.minimumMovement,
 					onPress: function() {
 						pauseTween();
 					},
@@ -176,6 +178,7 @@
 						type: "scrollTop",
 						throwProps: true,
 						edgeResistance: 0.95,
+						minimumMovement: this.options.minimumMovement,
 						onClick: function() {
 							$(self.element).trigger("scrollClick", [this.pointerEvent]);
 						}


### PR DESCRIPTION
- Adding an option `minimumMovement` to be provided to the instances of Draggable so that it will set how many pixels of movement is not considered a touch/click